### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Usage Example
 
   import busio
   import digitalio
-  from board import SCK, MOSI, MISO, D2, D2
+  from board import SCK, MOSI, MISO, D2, D3
 
   from adafruit_rgb_display import color565
   import adafruit_rgb_display.ili9341 as ili9341
@@ -64,7 +64,7 @@ Usage Example
       # Clear the screen blue.
       display.fill(color565(0, 0, 255))
       # Pause 2 seconds.
-  time.sleep(2)
+      time.sleep(2)
 
 API Reference
 =============


### PR DESCRIPTION
In the example code:
1. `D2` was imported twice as a typo. `D3` was meant to be imported in place of the mistaken second import of `D2`.
2. `time.sleep(2)` on the last line was mistakenly tabbed out of the scope of the infinite loop. The code would thus be unreachable making the command of filling the screen with blue too fast.