### PR TITLE
Make the SPI displays a little bit faster

### DIFF
--- a/adafruit_rgb_display/rgb.py
+++ b/adafruit_rgb_display/rgb.py
@@ -159,8 +159,8 @@ class Display: #pylint: disable-msg=no-member
 class DisplaySPI(Display):
     """Base class for SPI type devices"""
     #pylint: disable-msg=too-many-arguments
-    def __init__(self, spi, dc, cs, rst=None, width=1, height=1, baudrate=1000000,
-                 polarity=0, phase=0):
+    def __init__(self, spi, dc, cs, rst=None, width=1, height=1,
+                 baudrate=12000000, polarity=0, phase=0):
         self.spi_device = spi_device.SPIDevice(spi, cs, baudrate=baudrate,
                                                polarity=polarity, phase=phase)
         self.dc_pin = dc


### PR DESCRIPTION
Setting the SPI bus speed to 12MHz by default. Due to a bug in CP 2.x,
that's the maximum speed supported on all boards. When it's fixed, 24MHz
should be possible.