### PR TITLE
Renamed for use with multiple displays

### DIFF
--- a/examples/rgb_display_pillow_demo.py
+++ b/examples/rgb_display_pillow_demo.py
@@ -19,7 +19,7 @@ BAUDRATE = 24000000
 spi = board.SPI()
 
 # Create the ILI9341 display:
-disp = ili9341.ILI9341(spi, cs=cs_pin, dc=dc_pin, rst=reset_pin, baudrate=BAUDRATE)
+disp = ili9341.ILI9341(spi, cs=cs_pin, dc=dc_pin, rst=reset_pin, baudrate=BAUDRATE)     #ILI9341
 
 # Create blank image for drawing.
 # Make sure to create image with mode 'RGB' for full color.

--- a/examples/rgb_display_pillow_image.py
+++ b/examples/rgb_display_pillow_image.py
@@ -15,7 +15,7 @@ BAUDRATE = 64000000
 spi = board.SPI()
 
 # Create the ILI9341 display:
-disp = ili9341.ILI9341(spi, cs=cs_pin, dc=dc_pin, rst=reset_pin, baudrate=BAUDRATE)
+disp = ili9341.ILI9341(spi, cs=cs_pin, dc=dc_pin, rst=reset_pin, baudrate=BAUDRATE)     #ILI9341
 
 # Create blank image for drawing.
 # Make sure to create image with mode 'RGB' for full color.

--- a/examples/rgb_display_pillow_stats.py
+++ b/examples/rgb_display_pillow_stats.py
@@ -5,7 +5,6 @@ import board
 from PIL import Image, ImageDraw, ImageFont
 import adafruit_rgb_display.ili9341 as ili9341
 
-
 # Configuration for CS and DC pins (these are FeatherWing defaults on M0/M4):
 cs_pin = digitalio.DigitalInOut(board.CE0)
 dc_pin = digitalio.DigitalInOut(board.D25)
@@ -18,7 +17,7 @@ BAUDRATE = 24000000
 spi = board.SPI()
 
 # Create the ILI9341 display:
-disp = ili9341.ILI9341(spi, cs=cs_pin, dc=dc_pin, rst=reset_pin, baudrate=BAUDRATE)
+disp = ili9341.ILI9341(spi, cs=cs_pin, dc=dc_pin, rst=reset_pin, baudrate=BAUDRATE)     #ILI9341
 
 # Create blank image for drawing.
 # Make sure to create image with mode 'RGB' for full color.


### PR DESCRIPTION
These examples will be used with multiple displays like the EPD simpletest, so I thought I'd rename now so that I don't need to update guides twice.