### PR TITLE
Added 240x240 support to Pillow Examples, reorganized initializers

### DIFF
--- a/examples/rgb_display_pillow_demo.py
+++ b/examples/rgb_display_pillow_demo.py
@@ -19,9 +19,12 @@ BAUDRATE = 64000000
 # Setup SPI bus using hardware SPI:
 spi = board.SPI()
 
-# Create the ILI9341 display:
-disp = ili9341.ILI9341(spi, cs=cs_pin, dc=dc_pin, rst=reset_pin, baudrate=BAUDRATE)     #ILI9341
-#disp = st7789.ST7789(spi, cs=cs_pin, dc=dc_pin, rst=reset_pin, baudrate=BAUDRATE)      #ST7789
+# Create the display:
+#disp = st7789.ST7789(spi,                                         # 2.0" ST7789
+#disp = st7789.ST7789(spi, width=240, height=240, y_offset=80,     # 1.3", 1.54" ST7789
+disp = ili9341.ILI9341(spi,                                        # 2.2", 2.4", 2.8", 3.2" ILI9341
+                       cs=cs_pin, dc=dc_pin, rst=reset_pin, baudrate=BAUDRATE)
+
 
 # Create blank image for drawing.
 # Make sure to create image with mode 'RGB' for full color.

--- a/examples/rgb_display_pillow_image.py
+++ b/examples/rgb_display_pillow_image.py
@@ -15,9 +15,11 @@ BAUDRATE = 64000000
 # Setup SPI bus using hardware SPI:
 spi = board.SPI()
 
-# Create the ILI9341 display:
-disp = ili9341.ILI9341(spi, cs=cs_pin, dc=dc_pin, rst=reset_pin, baudrate=BAUDRATE)     #ILI9341
-#disp = st7789.ST7789(spi, cs=cs_pin, dc=dc_pin, rst=reset_pin, baudrate=BAUDRATE)      #ST7789
+# Create the display:
+#disp = st7789.ST7789(spi,                                         # 2.0" ST7789
+#disp = st7789.ST7789(spi, width=240, height=240, y_offset=80,     # 1.3", 1.54" ST7789
+disp = ili9341.ILI9341(spi,                                        # 2.2", 2.4", 2.8", 3.2" ILI9341
+                       cs=cs_pin, dc=dc_pin, rst=reset_pin, baudrate=BAUDRATE)
 
 # Create blank image for drawing.
 # Make sure to create image with mode 'RGB' for full color.

--- a/examples/rgb_display_pillow_stats.py
+++ b/examples/rgb_display_pillow_stats.py
@@ -17,9 +17,11 @@ BAUDRATE = 64000000
 # Setup SPI bus using hardware SPI:
 spi = board.SPI()
 
-# Create the ILI9341 display:
-disp = ili9341.ILI9341(spi, cs=cs_pin, dc=dc_pin, rst=reset_pin, baudrate=BAUDRATE)     #ILI9341
-#disp = st7789.ST7789(spi, cs=cs_pin, dc=dc_pin, rst=reset_pin, baudrate=BAUDRATE)      #ST7789
+# Create the display:
+#disp = st7789.ST7789(spi,                                         # 2.0" ST7789
+#disp = st7789.ST7789(spi, width=240, height=240, y_offset=80,     # 1.3", 1.54" ST7789
+disp = ili9341.ILI9341(spi,                                        # 2.2", 2.4", 2.8", 3.2" ILI9341
+                       cs=cs_pin, dc=dc_pin, rst=reset_pin, baudrate=BAUDRATE)
 
 # Create blank image for drawing.
 # Make sure to create image with mode 'RGB' for full color.


### PR DESCRIPTION
Rearranged the initializers to be more like the EPD library. This should make it easier to add more displays and for users' to change them.