### PR TITLE
Added rotation property and added HX8357 support

### DIFF
--- a/adafruit_rgb_display/hx8353.py
+++ b/adafruit_rgb_display/hx8353.py
@@ -74,5 +74,6 @@ class HX8353(DisplaySPI):
     _ENCODE_POS = ">HH"
 
     #pylint: disable-msg=useless-super-delegation, too-many-arguments
-    def __init__(self, spi, dc, cs, rst=None, width=128, height=128):
-        super().__init__(spi, dc, cs, rst, width, height)
+    def __init__(self, spi, dc, cs, rst=None, width=128, height=128,
+                 rotation=0):
+        super().__init__(spi, dc, cs, rst, width, height, rotation)

--- a/adafruit_rgb_display/hx8357.py
+++ b/adafruit_rgb_display/hx8357.py
@@ -102,6 +102,7 @@ class HX8357(DisplaySPI):
 
     #pylint: disable-msg=useless-super-delegation, too-many-arguments
     def __init__(self, spi, dc, cs, rst=None, width=480, height=320,
-                 baudrate=16000000, polarity=0, phase=0):
+                 baudrate=16000000, polarity=0, phase=0, rotation=0):
         super().__init__(spi, dc, cs, rst, width, height,
-                         baudrate=baudrate, polarity=polarity, phase=phase)
+                         baudrate=baudrate, polarity=polarity, phase=phase,
+                         rotation=rotation)

--- a/adafruit_rgb_display/ili9341.py
+++ b/adafruit_rgb_display/ili9341.py
@@ -90,9 +90,10 @@ class ILI9341(DisplaySPI):
 
     #pylint: disable-msg=too-many-arguments
     def __init__(self, spi, dc, cs, rst=None, width=240, height=320,
-                 baudrate=16000000, polarity=0, phase=0):
+                 baudrate=16000000, polarity=0, phase=0, rotation=0):
         super().__init__(spi, dc, cs, rst=rst, width=width, height=height,
-                         baudrate=baudrate, polarity=polarity, phase=phase)
+                         baudrate=baudrate, polarity=polarity, phase=phase,
+                         rotation=rotation)
         self._scroll = 0
     #pylint: enable-msg=too-many-arguments
 

--- a/adafruit_rgb_display/rgb.py
+++ b/adafruit_rgb_display/rgb.py
@@ -120,7 +120,9 @@ class Display: #pylint: disable-msg=no-member
     def __init__(self, width, height, rotation):
         self.width = width
         self.height = height
-        self.rotation = rotation
+        if rotation not in (0, 90, 180, 270):
+            raise ValueError('Rotation must be 0/90/180/270')
+        self._rotation = rotation
         self.init()
 
     def init(self):

--- a/adafruit_rgb_display/s6d02a1.py
+++ b/adafruit_rgb_display/s6d02a1.py
@@ -74,5 +74,5 @@ class S6D02A1(DisplaySPI):
     _ENCODE_POS = ">HH"
 
     #pylint: disable-msg=useless-super-delegation, too-many-arguments
-    def __init__(self, spi, dc, cs, rst=None, width=128, height=160):
-        super().__init__(spi, dc, cs, rst, width, height)
+    def __init__(self, spi, dc, cs, rst=None, width=128, height=160, rotation=0):
+        super().__init__(spi, dc, cs, rst, width, height, rotation)

--- a/adafruit_rgb_display/ssd1331.py
+++ b/adafruit_rgb_display/ssd1331.py
@@ -123,8 +123,8 @@ class SSD1331(DisplaySPI):
     # pylint: disable-msg=useless-super-delegation, too-many-arguments
     # super required to allow override of default values
     # All arguments needed due to driver requiring all the given data to function
-    def __init__(self, spi, dc, cs, rst=None, width=96, height=64):
-        super().__init__(spi, dc, cs, rst, width, height)
+    def __init__(self, spi, dc, cs, rst=None, width=96, height=64, rotation=0):
+        super().__init__(spi, dc, cs, rst, width, height, rotation)
 
     # pylint: disable=no-member
     def write(self, command=None, data=None):

--- a/adafruit_rgb_display/ssd1351.py
+++ b/adafruit_rgb_display/ssd1351.py
@@ -115,5 +115,5 @@ class SSD1351(DisplaySPI):
 
     #pylint: disable-msg=useless-super-delegation, too-many-arguments
     def __init__(self, spi, dc, cs, rst=None, width=128, height=128,
-                 rotation=rotation):
+                 rotation=0):
         super().__init__(spi, dc, cs, rst, width, height, rotation)

--- a/adafruit_rgb_display/ssd1351.py
+++ b/adafruit_rgb_display/ssd1351.py
@@ -114,5 +114,6 @@ class SSD1351(DisplaySPI):
     _ENCODE_POS = ">BB"
 
     #pylint: disable-msg=useless-super-delegation, too-many-arguments
-    def __init__(self, spi, dc, cs, rst=None, width=128, height=128):
-        super().__init__(spi, dc, cs, rst, width, height)
+    def __init__(self, spi, dc, cs, rst=None, width=128, height=128,
+                 rotation=rotation):
+        super().__init__(spi, dc, cs, rst, width, height, rotation)

--- a/adafruit_rgb_display/st7735.py
+++ b/adafruit_rgb_display/st7735.py
@@ -133,8 +133,8 @@ class ST7735(DisplaySPI):
     _ENCODE_POS = ">HH"
 
     #pylint: disable-msg=useless-super-delegation, too-many-arguments
-    def __init__(self, spi, dc, cs, rst=None, width=128, height=128):
-        super().__init__(spi, dc, cs, rst, width, height)
+    def __init__(self, spi, dc, cs, rst=None, width=128, height=128, rotation=0):
+        super().__init__(spi, dc, cs, rst, width, height, rotation)
 
 
 class ST7735R(ST7735):
@@ -167,8 +167,8 @@ class ST7735R(ST7735):
     )
 
     #pylint: disable-msg=useless-super-delegation, too-many-arguments
-    def __init__(self, spi, dc, cs, rst=None, width=128, height=160):
-        super().__init__(spi, dc, cs, rst, width, height)
+    def __init__(self, spi, dc, cs, rst=None, width=128, height=160, rotation=0):
+        super().__init__(spi, dc, cs, rst, width, height, rotation)
 
     def init(self):
         super().init()

--- a/adafruit_rgb_display/st7789.py
+++ b/adafruit_rgb_display/st7789.py
@@ -114,10 +114,10 @@ class ST7789(DisplaySPI):
     #pylint: disable-msg=useless-super-delegation, too-many-arguments
     def __init__(self, spi, dc, cs, rst=None, width=240, height=320,
                  baudrate=16000000, polarity=0, phase=0, *,
-                 x_offset=0, y_offset=0):
+                 x_offset=0, y_offset=0, rotation=0):
         super().__init__(spi, dc, cs, rst, width, height,
                          baudrate=baudrate, polarity=polarity, phase=phase,
-                         x_offset=x_offset, y_offset=y_offset)
+                         x_offset=x_offset, y_offset=y_offset, rotation=rotation)
     def init(self):
 
         super().init()

--- a/examples/rgb_display_pillow_demo.py
+++ b/examples/rgb_display_pillow_demo.py
@@ -3,6 +3,7 @@ import board
 from PIL import Image, ImageDraw, ImageFont
 import adafruit_rgb_display.ili9341 as ili9341
 import adafruit_rgb_display.st7789 as st7789        # pylint: disable=unused-import
+import adafruit_rgb_display.hx8357 as hx8357        # pylint: disable=unused-import
 
 # First define some constants to allow easy resizing of shapes.
 BORDER = 20
@@ -14,31 +15,35 @@ dc_pin = digitalio.DigitalInOut(board.D25)
 reset_pin = digitalio.DigitalInOut(board.D24)
 
 # Config for display baudrate (default max is 24mhz):
-BAUDRATE = 64000000
+BAUDRATE = 24000000
 
 # Setup SPI bus using hardware SPI:
 spi = board.SPI()
 
 # Create the display:
-#disp = st7789.ST7789(spi,                                         # 2.0" ST7789
-#disp = st7789.ST7789(spi, width=240, height=240, y_offset=80,     # 1.3", 1.54" ST7789
-disp = ili9341.ILI9341(spi,                                        # 2.2", 2.4", 2.8", 3.2" ILI9341
+#disp = st7789.ST7789(spi, rotation=90                          # 2.0" ST7789
+#disp = st7789.ST7789(spi, height=240, y_offset=80, rotation=90 # 1.3", 1.54" ST7789
+#disp = hx8357.HX8357(spi, rotation=180,                        # 3.5" HX8357
+disp = ili9341.ILI9341(spi,                                     # 2.2", 2.4", 2.8", 3.2" ILI9341
                        cs=cs_pin, dc=dc_pin, rst=reset_pin, baudrate=BAUDRATE)
-
 
 # Create blank image for drawing.
 # Make sure to create image with mode 'RGB' for full color.
-height = disp.width   # we swap height/width to rotate it to landscape!
-width = disp.height
+if disp.rotation % 180 == 90:
+    height = disp.width   # we swap height/width to rotate it to landscape!
+    width = disp.height
+else:
+    width = disp.width   # we swap height/width to rotate it to landscape!
+    height = disp.height
+
 image = Image.new('RGB', (width, height))
-rotation = 90
 
 # Get drawing object to draw on image.
 draw = ImageDraw.Draw(image)
 
 # Draw a green filled box as the background
 draw.rectangle((0, 0, width, height), fill=(0, 255, 0))
-disp.image(image, rotation)
+disp.image(image)
 
 # Draw a smaller inner purple rectangle
 draw.rectangle((BORDER, BORDER, width - BORDER - 1, height - BORDER - 1),
@@ -54,4 +59,4 @@ draw.text((width//2 - font_width//2, height//2 - font_height//2),
           text, font=font, fill=(255, 255, 0))
 
 # Display image.
-disp.image(image, rotation)
+disp.image(image)

--- a/examples/rgb_display_pillow_demo.py
+++ b/examples/rgb_display_pillow_demo.py
@@ -24,7 +24,7 @@ spi = board.SPI()
 #disp = st7789.ST7789(spi, rotation=90                          # 2.0" ST7789
 #disp = st7789.ST7789(spi, height=240, y_offset=80, rotation=90 # 1.3", 1.54" ST7789
 #disp = hx8357.HX8357(spi, rotation=180,                        # 3.5" HX8357
-disp = ili9341.ILI9341(spi,                                     # 2.2", 2.4", 2.8", 3.2" ILI9341
+disp = ili9341.ILI9341(spi, rotation=90,                        # 2.2", 2.4", 2.8", 3.2" ILI9341
                        cs=cs_pin, dc=dc_pin, rst=reset_pin, baudrate=BAUDRATE)
 
 # Create blank image for drawing.

--- a/examples/rgb_display_pillow_image.py
+++ b/examples/rgb_display_pillow_image.py
@@ -20,7 +20,7 @@ spi = board.SPI()
 #disp = st7789.ST7789(spi, rotation=90                          # 2.0" ST7789
 #disp = st7789.ST7789(spi, height=240, y_offset=80, rotation=90 # 1.3", 1.54" ST7789
 #disp = hx8357.HX8357(spi, rotation=180,                        # 3.5" HX8357
-disp = ili9341.ILI9341(spi,                                     # 2.2", 2.4", 2.8", 3.2" ILI9341
+disp = ili9341.ILI9341(spi, rotation=90,                        # 2.2", 2.4", 2.8", 3.2" ILI9341
                        cs=cs_pin, dc=dc_pin, rst=reset_pin, baudrate=BAUDRATE)
 
 # Create blank image for drawing.

--- a/examples/rgb_display_pillow_image.py
+++ b/examples/rgb_display_pillow_image.py
@@ -3,6 +3,7 @@ import board
 from PIL import Image, ImageDraw
 import adafruit_rgb_display.ili9341 as ili9341
 import adafruit_rgb_display.st7789 as st7789        # pylint: disable=unused-import
+import adafruit_rgb_display.hx8357 as hx8357        # pylint: disable=unused-import
 
 # Configuration for CS and DC pins (these are PiTFT defaults):
 cs_pin = digitalio.DigitalInOut(board.CE0)
@@ -10,30 +11,34 @@ dc_pin = digitalio.DigitalInOut(board.D25)
 reset_pin = digitalio.DigitalInOut(board.D24)
 
 # Config for display baudrate (default max is 24mhz):
-BAUDRATE = 64000000
+BAUDRATE = 24000000
 
 # Setup SPI bus using hardware SPI:
 spi = board.SPI()
 
 # Create the display:
-#disp = st7789.ST7789(spi,                                         # 2.0" ST7789
-#disp = st7789.ST7789(spi, width=240, height=240, y_offset=80,     # 1.3", 1.54" ST7789
-disp = ili9341.ILI9341(spi,                                        # 2.2", 2.4", 2.8", 3.2" ILI9341
+#disp = st7789.ST7789(spi, rotation=90                          # 2.0" ST7789
+#disp = st7789.ST7789(spi, height=240, y_offset=80, rotation=90 # 1.3", 1.54" ST7789
+#disp = hx8357.HX8357(spi, rotation=180,                        # 3.5" HX8357
+disp = ili9341.ILI9341(spi,                                     # 2.2", 2.4", 2.8", 3.2" ILI9341
                        cs=cs_pin, dc=dc_pin, rst=reset_pin, baudrate=BAUDRATE)
 
 # Create blank image for drawing.
 # Make sure to create image with mode 'RGB' for full color.
-height = disp.width   # we swap height/width to rotate it to landscape!
-width = disp.height
+if disp.rotation % 180 == 90:
+    height = disp.width   # we swap height/width to rotate it to landscape!
+    width = disp.height
+else:
+    width = disp.width   # we swap height/width to rotate it to landscape!
+    height = disp.height
 image = Image.new('RGB', (width, height))
-rotation = 90
 
 # Get drawing object to draw on image.
 draw = ImageDraw.Draw(image)
 
 # Draw a black filled box to clear the image.
 draw.rectangle((0, 0, width, height), outline=0, fill=(0, 0, 0))
-disp.image(image, rotation)
+disp.image(image)
 
 image = Image.open("blinka.jpg")
 
@@ -54,4 +59,4 @@ y = scaled_height // 2 - height // 2
 image = image.crop((x, y, x + width, y + height))
 
 # Display image.
-disp.image(image, rotation)
+disp.image(image)

--- a/examples/rgb_display_pillow_stats.py
+++ b/examples/rgb_display_pillow_stats.py
@@ -5,6 +5,7 @@ import board
 from PIL import Image, ImageDraw, ImageFont
 import adafruit_rgb_display.ili9341 as ili9341
 import adafruit_rgb_display.st7789 as st7789        # pylint: disable=unused-import
+import adafruit_rgb_display.hx8357 as hx8357        # pylint: disable=unused-import
 
 # Configuration for CS and DC pins (these are PiTFT defaults):
 cs_pin = digitalio.DigitalInOut(board.CE0)
@@ -12,30 +13,35 @@ dc_pin = digitalio.DigitalInOut(board.D25)
 reset_pin = digitalio.DigitalInOut(board.D24)
 
 # Config for display baudrate (default max is 24mhz):
-BAUDRATE = 64000000
+BAUDRATE = 24000000
 
 # Setup SPI bus using hardware SPI:
 spi = board.SPI()
 
 # Create the display:
-#disp = st7789.ST7789(spi,                                         # 2.0" ST7789
-#disp = st7789.ST7789(spi, width=240, height=240, y_offset=80,     # 1.3", 1.54" ST7789
-disp = ili9341.ILI9341(spi,                                        # 2.2", 2.4", 2.8", 3.2" ILI9341
+#disp = st7789.ST7789(spi, rotation=90                          # 2.0" ST7789
+#disp = st7789.ST7789(spi, height=240, y_offset=80, rotation=90 # 1.3", 1.54" ST7789
+#disp = hx8357.HX8357(spi, rotation=180,                        # 3.5" HX8357
+disp = ili9341.ILI9341(spi,                                     # 2.2", 2.4", 2.8", 3.2" ILI9341
                        cs=cs_pin, dc=dc_pin, rst=reset_pin, baudrate=BAUDRATE)
 
 # Create blank image for drawing.
 # Make sure to create image with mode 'RGB' for full color.
-height = disp.width   # we swap height/width to rotate it to landscape!
-width = disp.height
+if disp.rotation % 180 == 90:
+    height = disp.width   # we swap height/width to rotate it to landscape!
+    width = disp.height
+else:
+    width = disp.width   # we swap height/width to rotate it to landscape!
+    height = disp.height
+
 image = Image.new('RGB', (width, height))
-rotation = 90
 
 # Get drawing object to draw on image.
 draw = ImageDraw.Draw(image)
 
 # Draw a black filled box to clear the image.
 draw.rectangle((0, 0, width, height), outline=0, fill=(0, 0, 0))
-disp.image(image, rotation)
+disp.image(image)
 
 # First define some constants to allow easy positioning of text.
 padding = -2
@@ -76,5 +82,5 @@ while True:
     draw.text((x, y), Temp, font=font, fill="#FF00FF")
 
     # Display image.
-    disp.image(image, rotation)
+    disp.image(image)
     time.sleep(.1)

--- a/examples/rgb_display_pillow_stats.py
+++ b/examples/rgb_display_pillow_stats.py
@@ -22,7 +22,7 @@ spi = board.SPI()
 #disp = st7789.ST7789(spi, rotation=90                          # 2.0" ST7789
 #disp = st7789.ST7789(spi, height=240, y_offset=80, rotation=90 # 1.3", 1.54" ST7789
 #disp = hx8357.HX8357(spi, rotation=180,                        # 3.5" HX8357
-disp = ili9341.ILI9341(spi,                                     # 2.2", 2.4", 2.8", 3.2" ILI9341
+disp = ili9341.ILI9341(spi, rotation=90,                        # 2.2", 2.4", 2.8", 3.2" ILI9341
                        cs=cs_pin, dc=dc_pin, rst=reset_pin, baudrate=BAUDRATE)
 
 # Create blank image for drawing.


### PR DESCRIPTION
As I was adding displays to the Pillow examples, I've noticed that for some displays 90 degrees is landscape and some it is portrait. This is not too difficult to deal except I figured it would be even easier if we could place it in the initialization like it is in displayio now.

I added a kw arg rotation property that can be passed in the initialization so the user will only need to uncomment one line. Also, the way I added it, it is completely backwards compatible.

I added HX8357 support to the Pillow examples and updated the examples to take advantage of the rotation property in the initializer. It then reads the property to determine if the with and height variables need to be swapped.

Tested on the HX8357 and ILI9341 displays.