### PR TITLE
Fixed Pillow examples to match fritzing diagrams

### DIFF
--- a/examples/rgb_display_pillow_demo.py
+++ b/examples/rgb_display_pillow_demo.py
@@ -14,8 +14,8 @@ FONTSIZE = 24
 
 # Configuration for CS and DC pins (these are PiTFT defaults):
 cs_pin = digitalio.DigitalInOut(board.CE0)
-dc_pin = digitalio.DigitalInOut(board.D25)
-reset_pin = digitalio.DigitalInOut(board.D24)
+dc_pin = digitalio.DigitalInOut(board.D24)
+reset_pin = digitalio.DigitalInOut(board.D25)
 
 # Config for display baudrate (default max is 24mhz):
 BAUDRATE = 24000000

--- a/examples/rgb_display_pillow_image.py
+++ b/examples/rgb_display_pillow_image.py
@@ -10,8 +10,8 @@ import adafruit_rgb_display.ssd1331 as ssd1331      # pylint: disable=unused-imp
 
 # Configuration for CS and DC pins (these are PiTFT defaults):
 cs_pin = digitalio.DigitalInOut(board.CE0)
-dc_pin = digitalio.DigitalInOut(board.D25)
-reset_pin = digitalio.DigitalInOut(board.D24)
+dc_pin = digitalio.DigitalInOut(board.D24)
+reset_pin = digitalio.DigitalInOut(board.D25)
 
 # Config for display baudrate (default max is 24mhz):
 BAUDRATE = 24000000

--- a/examples/rgb_display_pillow_stats.py
+++ b/examples/rgb_display_pillow_stats.py
@@ -12,8 +12,8 @@ import adafruit_rgb_display.ssd1331 as ssd1331      # pylint: disable=unused-imp
 
 # Configuration for CS and DC pins (these are PiTFT defaults):
 cs_pin = digitalio.DigitalInOut(board.CE0)
-dc_pin = digitalio.DigitalInOut(board.D25)
-reset_pin = digitalio.DigitalInOut(board.D24)
+dc_pin = digitalio.DigitalInOut(board.D24)
+reset_pin = digitalio.DigitalInOut(board.D25)
 
 # Config for display baudrate (default max is 24mhz):
 BAUDRATE = 24000000


### PR DESCRIPTION
This is to fix it so the pinouts in the examples match the pinouts in the Fritzing diagrams.