### PR TITLE
Use numpy for bulk pixel data conversion

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,8 @@ Please ensure all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading
 `the Adafruit library and driver bundle <https://github.com/adafruit/Adafruit_CircuitPython_Bundle>`_.
 
+For improved performance consider installing numpy.
+
 Installing from PyPI
 ====================
 


### PR DESCRIPTION
This brings back the Numpy approach to converting pixel data for the SPI
interface from the original Adafruit_Python_ILI9341 library. The use of
Numpy instead of the previous double loop results in a performance boost
of a factor >10 when testing on a Raspberry Pi Zero.

Fixes #46