### PR TITLE
Add missing time import in example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,7 @@ Usage Example
 
 .. code-block:: python
 
+  import time
   import busio
   import digitalio
   from board import SCK, MOSI, MISO, D2, D3


### PR DESCRIPTION
When copy/pasted, the example otherwise doesn't run due
to the usage of `time.sleep` in the code.