### PR TITLE
make numpy speed improvements more prominent

### DIFF
--- a/adafruit_rgb_display/rgb.py
+++ b/adafruit_rgb_display/rgb.py
@@ -180,9 +180,10 @@ class Display: #pylint: disable-msg=no-member
         """Set buffer to value of Python Imaging Library image. The image should
         be in 1 bit mode and a size not exceeding the display size when drawn at
         the supplied origin.
+        
         :param no_numpy: set this to true if you want to force to run image()
-                         without numpy. This will suffer from being around 8 times
-                         as slow as it would be with numpy.
+               without numpy. This will suffer from being around 8 times
+               as slow as it would be with numpy.
         """
         if rotation is None:
             rotation = self.rotation

--- a/adafruit_rgb_display/rgb.py
+++ b/adafruit_rgb_display/rgb.py
@@ -180,7 +180,7 @@ class Display: #pylint: disable-msg=no-member
         """Set buffer to value of Python Imaging Library image. The image should
         be in 1 bit mode and a size not exceeding the display size when drawn at
         the supplied origin.
-        
+
         :param no_numpy: set this to true if you want to force to run image()
                without numpy. This will suffer from being around 8 times
                as slow as it would be with numpy.

--- a/adafruit_rgb_display/rgb.py
+++ b/adafruit_rgb_display/rgb.py
@@ -175,6 +175,7 @@ class Display: #pylint: disable-msg=no-member
             self._block(x, y, x, y, self._encode_pixel(color))
         return None
 
+    #pylint: disable-msg=too-many-arguments
     def image(self, img, rotation=None, x=0, y=0, no_numpy=False):
         """Set buffer to value of Python Imaging Library image. The image should
         be in 1 bit mode and a size not exceeding the display size when drawn at
@@ -201,7 +202,7 @@ class Display: #pylint: disable-msg=no-member
             # Slower but doesn't require numpy
             if not no_numpy:
                 raise ValueError('numpy not found. Either install numpy or run with'
-                'no_numpy=True (will be around 8 times slower though!)')
+                                 'no_numpy=True (will be around 8 times slower though!)')
             pixels = bytearray(imwidth * imheight * 2)
             for i in range(imwidth):
                 for j in range(imheight):

--- a/adafruit_rgb_display/rgb.py
+++ b/adafruit_rgb_display/rgb.py
@@ -175,10 +175,14 @@ class Display: #pylint: disable-msg=no-member
             self._block(x, y, x, y, self._encode_pixel(color))
         return None
 
-    def image(self, img, rotation=None, x=0, y=0):
+    def image(self, img, rotation=None, x=0, y=0, no_numpy=False):
         """Set buffer to value of Python Imaging Library image. The image should
         be in 1 bit mode and a size not exceeding the display size when drawn at
-        the supplied origin."""
+        the supplied origin.
+        :param no_numpy: set this to true if you want to force to run image()
+                         without numpy. This will suffer from being around 8 times
+                         as slow as it would be with numpy.
+        """
         if rotation is None:
             rotation = self.rotation
         if not img.mode in ('RGB', 'RGBA'):
@@ -195,6 +199,9 @@ class Display: #pylint: disable-msg=no-member
             pixels = list(image_to_data(img))
         else:
             # Slower but doesn't require numpy
+            if not no_numpy:
+                raise ValueError('numpy not found. Either install numpy or run with'
+                'no_numpy=True (will be around 8 times slower though!)')
             pixels = bytearray(imwidth * imheight * 2)
             for i in range(imwidth):
                 for j in range(imheight):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Adafruit-Blinka
 adafruit-circuitpython-busdevice
+numpy


### PR DESCRIPTION
Following up on [ladyadas comment](https://github.com/adafruit/Adafruit_CircuitPython_RGB_Display/issues/61#issuecomment-573388331) I tried to make numpy's speed improvement more prominent.

That's how I approach that. Of course this could be solved in other ways, some alternatives I considered:

- output a warning on stderr when numpy can't be imported (at top of `rgb.py`), but this is annoying for anyone who wants to run without numpy
- explicitly require numpy, remove code in `image()` that handles when numpy is not there. I didn't dare to do this but might be the most straightforward way. But there might be situations for users where they don't want numpy as it's probably quite heavy to install.
- not adding numpy to `requirements.txt`, but I think it's best to lead users to the usually best way to roll