### PR TITLE
Added missing commas and 240x240 better rotation

### DIFF
--- a/examples/rgb_display_pillow_animated_gif.py
+++ b/examples/rgb_display_pillow_animated_gif.py
@@ -156,8 +156,8 @@ spi = board.SPI()
 
 # pylint: disable=line-too-long
 # Create the display:
-#disp = st7789.ST7789(spi, rotation=90                             # 2.0" ST7789
-#disp = st7789.ST7789(spi, height=240, y_offset=80, rotation=90    # 1.3", 1.54" ST7789
+#disp = st7789.ST7789(spi, rotation=90,                            # 2.0" ST7789
+#disp = st7789.ST7789(spi, height=240, y_offset=80, rotation=180,  # 1.3", 1.54" ST7789
 #disp = st7789.ST7789(spi, rotation=90, width=135, height=240, x_offset=53, y_offset=40, # 1.14" ST7789
 #disp = hx8357.HX8357(spi, rotation=180,                           # 3.5" HX8357
 #disp = st7735.ST7735R(spi, rotation=90,                           # 1.8" ST7735R

--- a/examples/rgb_display_pillow_demo.py
+++ b/examples/rgb_display_pillow_demo.py
@@ -25,8 +25,8 @@ spi = board.SPI()
 
 # pylint: disable=line-too-long
 # Create the display:
-#disp = st7789.ST7789(spi, rotation=90                             # 2.0" ST7789
-#disp = st7789.ST7789(spi, height=240, y_offset=80, rotation=90    # 1.3", 1.54" ST7789
+#disp = st7789.ST7789(spi, rotation=90,                            # 2.0" ST7789
+#disp = st7789.ST7789(spi, height=240, y_offset=80, rotation=180,  # 1.3", 1.54" ST7789
 #disp = st7789.ST7789(spi, rotation=90, width=135, height=240, x_offset=53, y_offset=40, # 1.14" ST7789
 #disp = hx8357.HX8357(spi, rotation=180,                           # 3.5" HX8357
 #disp = st7735.ST7735R(spi, rotation=90,                           # 1.8" ST7735R

--- a/examples/rgb_display_pillow_image.py
+++ b/examples/rgb_display_pillow_image.py
@@ -22,7 +22,7 @@ spi = board.SPI()
 # pylint: disable=line-too-long
 # Create the display:
 #disp = st7789.ST7789(spi, rotation=90,                            # 2.0" ST7789
-#disp = st7789.ST7789(spi, height=240, y_offset=80, rotation=90,   # 1.3", 1.54" ST7789
+#disp = st7789.ST7789(spi, height=240, y_offset=80, rotation=180,  # 1.3", 1.54" ST7789
 #disp = st7789.ST7789(spi, rotation=90, width=135, height=240, x_offset=53, y_offset=40, # 1.14" ST7789
 #disp = hx8357.HX8357(spi, rotation=180,                           # 3.5" HX8357
 #disp = st7735.ST7735R(spi, rotation=90,                           # 1.8" ST7735R

--- a/examples/rgb_display_pillow_stats.py
+++ b/examples/rgb_display_pillow_stats.py
@@ -23,8 +23,8 @@ spi = board.SPI()
 
 # pylint: disable=line-too-long
 # Create the display:
-#disp = st7789.ST7789(spi, rotation=90                             # 2.0" ST7789
-#disp = st7789.ST7789(spi, height=240, y_offset=80, rotation=90    # 1.3", 1.54" ST7789
+#disp = st7789.ST7789(spi, rotation=90,                            # 2.0" ST7789
+#disp = st7789.ST7789(spi, height=240, y_offset=80, rotation=180,  # 1.3", 1.54" ST7789
 #disp = st7789.ST7789(spi, rotation=90, width=135, height=240, x_offset=53, y_offset=40, # 1.14" ST7789
 #disp = hx8357.HX8357(spi, rotation=180,                           # 3.5" HX8357
 #disp = st7735.ST7735R(spi, rotation=90,                           # 1.8" ST7735R


### PR DESCRIPTION
While testing the 240x240 PiTFT, I noticed some missing commas and fixed them. I also changed the 240x240 display rotation to 180 because it looked better.