### PR TITLE
Removed displayio from examples

### DIFF
--- a/examples/rgb_display_hx8357test.py
+++ b/examples/rgb_display_hx8357test.py
@@ -1,17 +1,13 @@
 # Quick test of 3.5" TFT FeatherWing (HX8357) with Feather M0 or M4
-# This will work even on a device running displayio
 # Will fill the TFT black and put a red pixel in the center, wait 2 seconds,
 # then fill the screen blue (with no pixel), wait 2 seconds, and repeat.
 import time
 import random
 import digitalio
 import board
-import displayio
 
 from adafruit_rgb_display.rgb import color565
 import adafruit_rgb_display.hx8357 as hx8357
-
-displayio.release_displays()
 
 # Configuration for CS and DC pins (these are TFT FeatherWing defaults):
 cs_pin = digitalio.DigitalInOut(board.D9)

--- a/examples/rgb_display_simpletest.py
+++ b/examples/rgb_display_simpletest.py
@@ -6,12 +6,9 @@ import time
 import random
 import digitalio
 import board
-import displayio
 
 from adafruit_rgb_display.rgb import color565
 import adafruit_rgb_display.st7789 as st7789
-
-displayio.release_displays()
 
 # Configuratoin for CS and DC pins (these are FeatherWing defaults on M0/M4):
 cs_pin = digitalio.DigitalInOut(board.D5)


### PR DESCRIPTION
Fixes #76. I think these may have had displayio in here as a result of testing on displays with displayio automatically loaded such as the PyPortal. However, this goes against using this library as an alternative to displayio.