### PR TITLE
Added text specifying Pillow Examples don't run in CircuitPython

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,11 @@ Please ensure all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading
 `the Adafruit library and driver bundle <https://github.com/adafruit/Adafruit_CircuitPython_Bundle>`_.
 
-For improved performance consider installing numpy.
+For the Pillow Examples, you will need to be running CPython. This means using a Single Board Computer
+such as a Raspberry Pi or using a chip such as an FT232H on Linux, Window, or Mac. CircuitPython does
+not support PIL/pillow (python imaging library)!
+
+For improved performance consider installing NumPy.
 
 Installing from PyPI
 ====================
@@ -149,7 +153,7 @@ With 1.14" `wiring <https://learn.adafruit.com/adafruit-1-14-240x135-color-tft-b
       display.fill(color565(0, 0, 255))
       # Pause 2 seconds.
       time.sleep(2)
-      
+
 
 Contributing
 ============

--- a/adafruit_rgb_display/ssd1331.py
+++ b/adafruit_rgb_display/ssd1331.py
@@ -156,5 +156,7 @@ class SSD1331(DisplaySPI):
         with self.spi_device as spi:
             if command is not None:
                 spi.write(bytearray([command]))
+                print(bytearray([command]))
             if data is not None:
                 spi.write(data)
+                print(data)

--- a/examples/rgb_display_pillow_bonnet_buttons.py
+++ b/examples/rgb_display_pillow_bonnet_buttons.py
@@ -23,6 +23,11 @@
 # This example is for use on (Linux) computers that are using CPython with
 # Adafruit Blinka to support CircuitPython libraries. CircuitPython does
 # not support PIL/pillow (python imaging library)!
+"""
+This example is for use on (Linux) computers that are using CPython with
+Adafruit Blinka to support CircuitPython libraries. CircuitPython does
+not support PIL/pillow (python imaging library)!
+"""
 
 import time
 import random

--- a/examples/rgb_display_pillow_demo.py
+++ b/examples/rgb_display_pillow_demo.py
@@ -1,3 +1,14 @@
+"""
+This demo will draw a few rectangles onto the screen along with some text
+on top of that.
+
+This example is for use on (Linux) computers that are using CPython with
+Adafruit Blinka to support CircuitPython libraries. CircuitPython does
+not support PIL/pillow (python imaging library)!
+
+Author(s): Melissa LeBlanc-Williams for Adafruit Industries
+"""
+
 import digitalio
 import board
 from PIL import Image, ImageDraw, ImageFont

--- a/examples/rgb_display_pillow_image.py
+++ b/examples/rgb_display_pillow_image.py
@@ -1,3 +1,13 @@
+"""
+Be sure to check the learn guides for more usage information.
+
+This example is for use on (Linux) computers that are using CPython with
+Adafruit Blinka to support CircuitPython libraries. CircuitPython does
+not support PIL/pillow (python imaging library)!
+
+Author(s): Melissa LeBlanc-Williams for Adafruit Industries
+"""
+
 import digitalio
 import board
 from PIL import Image, ImageDraw

--- a/examples/rgb_display_pillow_stats.py
+++ b/examples/rgb_display_pillow_stats.py
@@ -1,3 +1,13 @@
+"""
+This will show some Linux Statistics on the attached display. Be sure to adjust
+to the display you have connected. Be sure to check the learn guides for more
+usage information.
+
+This example is for use on (Linux) computers that are using CPython with
+Adafruit Blinka to support CircuitPython libraries. CircuitPython does
+not support PIL/pillow (python imaging library)!
+"""
+
 import time
 import subprocess
 import digitalio


### PR DESCRIPTION
Fixes #83.