### PR TITLE
Allow for other paths in rgb_display_pillow_animated_gif.py

### DIFF
--- a/examples/rgb_display_pillow_animated_gif.py
+++ b/examples/rgb_display_pillow_animated_gif.py
@@ -89,6 +89,7 @@ class AnimatedGif:
     def load_files(self, folder):
         gif_files = [f for f in os.listdir(folder) if f.endswith(".gif")]
         for gif_file in gif_files:
+            gif_file = os.path.join(folder, gif_file)
             image = Image.open(gif_file)
             # Only add animated Gifs
             if image.is_animated:


### PR DESCRIPTION
This concatenates the path defined by the user in the object instantiation of AnimatedGif in rgb_display_pillow_animated_gif.py to allow the files to be stored outside the current working directory.