### PR TITLE
Add delay to button presses in rgb_display_pillow_animated_gif.py

### DIFF
--- a/examples/rgb_display_pillow_animated_gif.py
+++ b/examples/rgb_display_pillow_animated_gif.py
@@ -139,11 +139,14 @@ class AnimatedGif:
             for frame_object in self._frames:
                 start_time = time.monotonic()
                 self.display.image(frame_object.image)
+                # If the user pressed a button, give them time (0.5s) to release it
                 if not self.advance_button.value:
                     self.advance()
+                    time.sleep(0.5)
                     return False
                 if not self.back_button.value:
                     self.back()
+                    time.sleep(0.5)
                     return False
                 while time.monotonic() < (start_time + frame_object.duration / 1000):
                     pass


### PR DESCRIPTION
This adds a slight delay to the looping in rgb_display_pillow_animated_gif.py when the user presses a back or advance button, because I found it difficult to use otherwise (skipped multiple files instead of one).