### PR TITLE
Fix Pillow resampling change in rgb_display_pillow_animated_gif.py

### DIFF
--- a/examples/rgb_display_pillow_animated_gif.py
+++ b/examples/rgb_display_pillow_animated_gif.py
@@ -13,6 +13,7 @@ Adafruit Blinka to support CircuitPython libraries. CircuitPython does
 not support PIL/pillow (python imaging library)!
 
 Author(s): Melissa LeBlanc-Williams for Adafruit Industries
+           Mike Mallett <mike@nerdcore.net>
 """
 import os
 import time
@@ -122,7 +123,7 @@ class AnimatedGif:
             frame_object.image = ImageOps.pad(  # pylint: disable=no-member
                 image.convert("RGB"),
                 (self._width, self._height),
-                method=Image.NEAREST,
+                method=Image.Resampling.NEAREST,
                 color=(0, 0, 0),
                 centering=(0.5, 0.5),
             )

--- a/examples/rgb_display_pillow_image.py
+++ b/examples/rgb_display_pillow_image.py
@@ -84,7 +84,7 @@ if screen_ratio < image_ratio:
 else:
     scaled_width = width
     scaled_height = image.height * width // image.width
-image = image.resize((scaled_width, scaled_height), Image.BICUBIC)
+image = image.resize((scaled_width, scaled_height), Image..Resampling.BICUBIC)
 
 # Crop and center the image
 x = scaled_width // 2 - width // 2

--- a/examples/rgb_display_pillow_image.py
+++ b/examples/rgb_display_pillow_image.py
@@ -84,7 +84,7 @@ if screen_ratio < image_ratio:
 else:
     scaled_width = width
     scaled_height = image.height * width // image.width
-image = image.resize((scaled_width, scaled_height), Image..Resampling.BICUBIC)
+image = image.resize((scaled_width, scaled_height), Image.Resampling.BICUBIC)
 
 # Crop and center the image
 x = scaled_width // 2 - width // 2


### PR DESCRIPTION
Pillow has deprecated use of "Image.NEAREST" for resampling method

https://github.com/python-pillow/Pillow/blob/main/docs/deprecations.rst#constants

This fixes the resampling call in rgb_display_pillow_animated_gif.py