### PR TITLE
catch only the r/g/b values when list is longer

### DIFF
--- a/adafruit_rgb_display/rgb.py
+++ b/adafruit_rgb_display/rgb.py
@@ -56,7 +56,7 @@ def color565(
     package namespace."""
     if isinstance(r, (tuple, list)):  # see if the first var is a tuple/list
         if len(r) >= 3:
-            red, g, b = r
+            red, g, b = r[0:3]
         else:
             raise ValueError(
                 "Not enough values to unpack (expected 3, got %d)" % len(r)


### PR DESCRIPTION
fixing an issue when 4 values are returned instead of r/g/b. Might be safer to always truncate the list to 3. Similar to issue #117 

```
(0, 0, 0, 0)
Traceback (most recent call last):
  File "/var/local/pproxy/git/home_device/usr/local/pproxy/tests/lcd_test.py", line 23, in <module>
    LCD.show_logo()
  File "/var/local/pproxy/git/home_device/usr/local/pproxy/tests/../lcd.py", line 284, in show_logo
    self.lcd.image(image, x, y)
  File "/var/local/pproxy/wepn-env/lib/python3.9/site-packages/adafruit_rgb_display/rgb.py", line 231, in image
    pix = color565(img.getpixel((i, j)))
  File "/var/local/pproxy/wepn-env/lib/python3.9/site-packages/adafruit_rgb_display/rgb.py", line 59, in color565
    red, g, b = r
ValueError: too many values to unpack (expected 3)

```