### PR TITLE
SSD1331: removed print calls

### DIFF
--- a/adafruit_rgb_display/ssd1331.py
+++ b/adafruit_rgb_display/ssd1331.py
@@ -149,7 +149,5 @@ class SSD1331(DisplaySPI):
         with self.spi_device as spi:
             if command is not None:
                 spi.write(bytearray([command]))
-                print(bytearray([command]))
             if data is not None:
                 spi.write(data)
-                print(data)


### PR DESCRIPTION
I just noticed that the write function of the SSD1331 driver prints out the data and command. I assume that this was simply an unintended leftover and I've removed both print calls in this pull request.